### PR TITLE
Correctly qualify include in subdirectory

### DIFF
--- a/src/Arduino_Due_SD_HSMCI.cpp
+++ b/src/Arduino_Due_SD_HSMCI.cpp
@@ -1,5 +1,5 @@
 #include "Arduino_Due_SD_HSMCI.h"
-#include <SD_HSMCI.h>
+#include <SD_HSMCI/SD_HSMCI.h>
 
 /*
  * Debug Functions (Change output channel if needed)

--- a/src/Arduino_Due_SD_HSMCI.h
+++ b/src/Arduino_Due_SD_HSMCI.h
@@ -28,7 +28,7 @@ Licence: MIT
 // Platform-specific includes
 #include "Arduino.h"
 #include "Configuration.h"
-#include <SD_HSMCI.h>
+#include <SD_HSMCI/SD_HSMCI.h>
 
 /**************************************************************************************************/
 


### PR DESCRIPTION
This fixes an issue that was causing manually modifying the library or rearranging the files in order to compile.